### PR TITLE
Enable/disable MySQL native column types

### DIFF
--- a/system/database/drivers/pdo/subdrivers/pdo_mysql_driver.php
+++ b/system/database/drivers/pdo/subdrivers/pdo_mysql_driver.php
@@ -83,6 +83,15 @@ class CI_DB_pdo_mysql_driver extends CI_DB_pdo_driver {
 	 * @var	string
 	 */
 	protected $_escape_char = '`';
+	
+        /**
+         * Determines whether results should return the native column type.
+         * By default this is disabled to be BC. Set this to true in config/database.php
+         * to let integers be integers, NULLS be NULLS etc
+         *
+         * @var bool
+         */
+         public $use_native_types = FALSE;
 
 	// --------------------------------------------------------------------
 
@@ -184,6 +193,12 @@ class CI_DB_pdo_mysql_driver extends CI_DB_pdo_driver {
 			log_message('error', $message);
 			return ($this->db->db_debug) ? $this->db->display_error($message, '', TRUE) : FALSE;
 		}
+		
+		if ($this->use_native_types)
+        	{
+            		$pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+            		$pdo->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
+        	}
 
 		return $pdo;
 	}


### PR DESCRIPTION
Added option to enable/ disable returning native MySQL column types.
The option is disabled by default, so it will not change the default behaviour.

This can be enabled in config/database.php by setting the subdriver to 'mysql' and use_native_types to TRUE.
DO NOT USE THE DSN!

Example:
```
        'dsn' => NULL,
	'hostname' => 'localhost',
	'username' => 'YOUR_USERNAME',
	'password' => 'YOUR_PASSWORD',
	'database' => 'YOUR_DATABASE',
	'dbdriver' => 'pdo',
	'subdriver' => 'mysql',
	'use_native_types' => TRUE,
```